### PR TITLE
Improve markdown editor with stylish toolbar and preview functionality

### DIFF
--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Box, useColorMode } from '@chakra-ui/react'
+import React, { useRef, useCallback, useEffect } from 'react'
+import { Box, useColorMode, useToast } from '@chakra-ui/react'
 import MDEditor from '@uiw/react-md-editor'
 import '@uiw/react-md-editor/markdown-editor.css'
 import '@uiw/react-markdown-preview/markdown.css'
@@ -11,6 +11,130 @@ interface MarkdownEditorProps {
 
 const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange }) => {
   const { colorMode } = useColorMode()
+  const toast = useToast()
+  const editorRef = useRef<HTMLDivElement>(null)
+
+  // 画像をBase64に変換
+  const fileToBase64 = useCallback((file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+  }, [])
+
+  // クリップボードペーストイベント処理
+  const handlePaste = useCallback(async (event: React.ClipboardEvent) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      
+      // 画像ファイルの場合
+      if (item.type.startsWith('image/')) {
+        event.preventDefault()
+        
+        const file = item.getAsFile()
+        if (!file) continue
+
+        try {
+          // Base64に変換
+          const base64 = await fileToBase64(file)
+          
+          // 現在のカーソル位置に画像マークダウンを挿入
+          const imageMarkdown = `\n![画像](${base64})\n`
+          
+          // テキストエリアの現在位置を取得してマークダウンを挿入
+          const textarea = editorRef.current?.querySelector('.w-md-editor-text-textarea') as HTMLTextAreaElement
+          if (textarea) {
+            const start = textarea.selectionStart
+            const end = textarea.selectionEnd
+            const newValue = value.slice(0, start) + imageMarkdown + value.slice(end)
+            onChange(newValue)
+            
+            // カーソル位置を画像マークダウンの後に移動
+            setTimeout(() => {
+              textarea.setSelectionRange(start + imageMarkdown.length, start + imageMarkdown.length)
+              textarea.focus()
+            }, 0)
+          } else {
+            // フォールバック: 末尾に追加
+            onChange(value + imageMarkdown)
+          }
+
+          toast({
+            title: '画像を挿入しました',
+            status: 'success',
+            duration: 2000,
+            isClosable: true,
+          })
+        } catch (error) {
+          console.error('画像の処理中にエラーが発生しました:', error)
+          toast({
+            title: 'エラー',
+            description: '画像の処理に失敗しました',
+            status: 'error',
+            duration: 3000,
+            isClosable: true,
+          })
+        }
+        break
+      }
+    }
+  }, [value, onChange, fileToBase64, toast])
+
+  // より強力なIME対応
+  useEffect(() => {
+    const style = document.createElement('style')
+    style.textContent = `
+      .w-md-editor .w-md-editor-text-textarea,
+      .w-md-editor-text-textarea,
+      textarea.w-md-editor-text-textarea {
+        color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+        -webkit-text-fill-color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+        caret-color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+        background-color: ${colorMode === 'dark' ? '#2D3748' : '#FFFFFF'} !important;
+      }
+      .w-md-editor .w-md-editor-text-textarea:focus,
+      .w-md-editor-text-textarea:focus,
+      textarea.w-md-editor-text-textarea:focus {
+        color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+        -webkit-text-fill-color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+        outline: 2px solid #3182CE !important;
+      }
+      .w-md-editor .w-md-editor-text-textarea::selection,
+      .w-md-editor-text-textarea::selection {
+        background-color: ${colorMode === 'dark' ? 'rgba(66, 153, 225, 0.5)' : 'rgba(66, 153, 225, 0.3)'} !important;
+        color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+      }
+      /* IME変換中の文字に対する強制スタイル */
+      .w-md-editor .w-md-editor-text-textarea[style*="ime"],
+      .w-md-editor-text-textarea[style*="ime"] {
+        color: ${colorMode === 'dark' ? '#FFFFFF' : '#2D3748'} !important;
+      }
+    `
+    document.head.appendChild(style)
+    
+    // DOMが更新された後に再適用
+    const observer = new MutationObserver(() => {
+      const textareas = document.querySelectorAll('.w-md-editor-text-textarea')
+      textareas.forEach((textarea) => {
+        if (textarea instanceof HTMLTextAreaElement) {
+          textarea.style.color = colorMode === 'dark' ? '#FFFFFF' : '#2D3748'
+          textarea.style.webkitTextFillColor = colorMode === 'dark' ? '#FFFFFF' : '#2D3748'
+        }
+      })
+    })
+    
+    observer.observe(document.body, { childList: true, subtree: true })
+    
+    return () => {
+      document.head.removeChild(style)
+      observer.disconnect()
+    }
+  }, [colorMode])
 
   return (
     <Box
@@ -18,25 +142,72 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({ value, onChange }) => {
       sx={{
         '& .w-md-editor': {
           backgroundColor: colorMode === 'dark' ? 'var(--chakra-colors-gray-800)' : 'white',
+          border: '1px solid var(--chakra-colors-gray-200)',
         },
         '& .w-md-editor-text-pre, & .w-md-editor-text-input, & .w-md-editor-text': {
           backgroundColor: colorMode === 'dark' ? 'var(--chakra-colors-gray-700)' : 'white',
-          color: colorMode === 'dark' ? 'var(--chakra-colors-whiteAlpha-900)' : 'black',
+          color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          fontSize: '14px',
+          lineHeight: '1.5',
+        },
+        '& .w-md-editor-text-textarea': {
+          color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          backgroundColor: colorMode === 'dark' ? 'var(--chakra-colors-gray-700) !important' : 'white !important',
+          '-webkit-text-fill-color': colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+        },
+        '& .w-md-editor-text-area textarea': {
+          color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          '-webkit-text-fill-color': colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+        },
+        '& textarea.w-md-editor-text-textarea': {
+          color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          '-webkit-text-fill-color': colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          // IME変換中の文字色を修正
+          '&::placeholder': {
+            color: colorMode === 'dark' ? '#A0AEC0' : '#718096',
+          },
+          // IME変換候補の文字色
+          '&::-webkit-input-placeholder': {
+            color: colorMode === 'dark' ? '#A0AEC0' : '#718096',
+          },
+          // 変換中の下線付き文字の色
+          '&[data-ime-input]': {
+            color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          },
+        },
+        // より具体的なIME対応
+        '& .w-md-editor-text-textarea:focus': {
+          color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          '-webkit-text-fill-color': colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+        },
+        // 変換中の文字に対するスタイル
+        '& .w-md-editor-text-textarea[style*="text-decoration"]': {
+          color: colorMode === 'dark' ? 'white !important' : '#2D3748 !important',
+          textDecorationColor: colorMode === 'dark' ? 'white' : '#2D3748',
         },
         '& .w-md-editor-preview': {
           backgroundColor: colorMode === 'dark' ? 'var(--chakra-colors-gray-700)' : 'white',
-          color: colorMode === 'dark' ? 'var(--chakra-colors-whiteAlpha-900)' : 'black',
+          color: colorMode === 'dark' ? 'white' : '#2D3748',
+        },
+        '& .token.title': {
+          color: colorMode === 'dark' ? '#63B3ED' : '#3182CE',
+        },
+        '& .token.bold': {
+          color: colorMode === 'dark' ? 'white' : '#2D3748',
+          fontWeight: 'bold',
         },
       }}
     >
-      <MDEditor
-        value={value}
-        onChange={(val) => onChange(val || '')}
-        height={400}
-        preview="edit"
-        hideToolbar={false}
-        data-color-mode={colorMode}
-      />
+      <div ref={editorRef} onPaste={handlePaste}>
+        <MDEditor
+          value={value}
+          onChange={(val) => onChange(val || '')}
+          height={400}
+          preview="edit"
+          hideToolbar={false}
+          data-color-mode={colorMode}
+        />
+      </div>
     </Box>
   )
 }

--- a/src/components/editor/PlainTextEditor.tsx
+++ b/src/components/editor/PlainTextEditor.tsx
@@ -1,0 +1,408 @@
+import React, { useRef, useCallback } from 'react'
+import { 
+  Box, 
+  Textarea, 
+  HStack, 
+  VStack,
+  Button, 
+  useColorMode, 
+  useToast,
+  Text,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Tooltip,
+  Divider
+} from '@chakra-ui/react'
+import ReactMarkdown from 'react-markdown'
+// Material Design Icons は型の問題があるため削除
+
+interface PlainTextEditorProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+const PlainTextEditor: React.FC<PlainTextEditorProps> = ({ value, onChange }) => {
+  const { colorMode } = useColorMode()
+  const toast = useToast()
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // 画像をBase64に変換
+  const fileToBase64 = useCallback((file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+  }, [])
+
+  // クリップボードペーストイベント処理
+  const handlePaste = useCallback(async (event: React.ClipboardEvent) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      
+      if (item.type.startsWith('image/')) {
+        event.preventDefault()
+        
+        const file = item.getAsFile()
+        if (!file) continue
+
+        try {
+          const base64 = await fileToBase64(file)
+          const imageMarkdown = `\n![画像](${base64})\n`
+          
+          const textarea = textareaRef.current
+          if (textarea) {
+            const start = textarea.selectionStart
+            const end = textarea.selectionEnd
+            const newValue = value.slice(0, start) + imageMarkdown + value.slice(end)
+            onChange(newValue)
+            
+            setTimeout(() => {
+              textarea.setSelectionRange(start + imageMarkdown.length, start + imageMarkdown.length)
+              textarea.focus()
+            }, 0)
+          } else {
+            onChange(value + imageMarkdown)
+          }
+
+          toast({
+            title: '画像を挿入しました',
+            status: 'success',
+            duration: 2000,
+            isClosable: true,
+          })
+        } catch (error) {
+          console.error('画像の処理中にエラーが発生しました:', error)
+          toast({
+            title: 'エラー',
+            description: '画像の処理に失敗しました',
+            status: 'error',
+            duration: 3000,
+            isClosable: true,
+          })
+        }
+        break
+      }
+    }
+  }, [value, onChange, fileToBase64, toast])
+
+  // Markdownボタン機能
+  const insertMarkdown = useCallback((before: string, after: string = '') => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    const selectedText = value.slice(start, end)
+    
+    const newText = before + selectedText + after
+    const newValue = value.slice(0, start) + newText + value.slice(end)
+    
+    onChange(newValue)
+    
+    setTimeout(() => {
+      textarea.focus()
+      textarea.setSelectionRange(start + before.length, start + before.length + selectedText.length)
+    }, 0)
+  }, [value, onChange])
+
+  return (
+    <VStack spacing={4} align="stretch">
+      {/* スタイリッシュなツールバー */}
+      <Box
+        p={3}
+        bg={colorMode === 'dark' ? 'gray.700' : 'gray.50'}
+        borderRadius="lg"
+        border="1px solid"
+        borderColor={colorMode === 'dark' ? 'gray.600' : 'gray.200'}
+      >
+        <HStack spacing={1} flexWrap="wrap">
+          {/* 見出しグループ */}
+          <HStack spacing={1} mr={2}>
+            <Tooltip label="見出し1" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('# ')}
+                colorScheme="blue"
+                fontSize="xs"
+                fontWeight="bold"
+              >
+                H1
+              </Button>
+            </Tooltip>
+            <Tooltip label="見出し2" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('## ')}
+                colorScheme="blue"
+                fontSize="xs"
+                fontWeight="bold"
+              >
+                H2
+              </Button>
+            </Tooltip>
+            <Tooltip label="見出し3" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('### ')}
+                colorScheme="blue"
+                fontSize="xs"
+                fontWeight="bold"
+              >
+                H3
+              </Button>
+            </Tooltip>
+          </HStack>
+
+          <Divider orientation="vertical" height="30px" />
+
+          {/* テキスト装飾グループ */}
+          <HStack spacing={1} mx={2}>
+            <Tooltip label="太字" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('**', '**')}
+                colorScheme="blue"
+                fontSize="xs"
+                fontWeight="bold"
+              >
+                B
+              </Button>
+            </Tooltip>
+            <Tooltip label="斜体" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('*', '*')}
+                colorScheme="blue"
+                fontSize="xs"
+                fontStyle="italic"
+              >
+                I
+              </Button>
+            </Tooltip>
+            <Tooltip label="インラインコード" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('`', '`')}
+                colorScheme="blue"
+                fontSize="xs"
+                fontFamily="mono"
+              >
+                {'<>'}
+              </Button>
+            </Tooltip>
+          </HStack>
+
+          <Divider orientation="vertical" height="30px" />
+
+          {/* リスト・リンクグループ */}
+          <HStack spacing={1} mx={2}>
+            <Tooltip label="リスト" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('- ')}
+                colorScheme="blue"
+                fontSize="xs"
+              >
+                • List
+              </Button>
+            </Tooltip>
+            <Tooltip label="リンク" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('[', '](url)')}
+                colorScheme="blue"
+                fontSize="xs"
+              >
+                🔗
+              </Button>
+            </Tooltip>
+          </HStack>
+
+          <Divider orientation="vertical" height="30px" />
+
+          {/* その他グループ */}
+          <HStack spacing={1} ml={2}>
+            <Tooltip label="コードブロック" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('```\n', '\n```')}
+                colorScheme="blue"
+                fontFamily="mono"
+                fontSize="xs"
+              >
+                ```
+              </Button>
+            </Tooltip>
+            <Tooltip label="画像（Ctrl+V/Cmd+V でペースト可能）" placement="top">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => insertMarkdown('![', '](url)')}
+                colorScheme="blue"
+                fontSize="xs"
+              >
+                🖼️
+              </Button>
+            </Tooltip>
+          </HStack>
+        </HStack>
+      </Box>
+
+      {/* エディタ部分をタブで切り替え */}
+      <Tabs variant="enclosed" colorScheme="blue">
+        <TabList>
+          <Tab>編集</Tab>
+          <Tab>プレビュー</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel p={0}>
+            <Box>
+              <Text fontSize="sm" color="gray.500" mb={2}>
+                Markdownで記事を書いてください（画像はCtrl+V/Cmd+Vで貼り付け可能）
+              </Text>
+              <Textarea
+                ref={textareaRef}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onPaste={handlePaste}
+                placeholder="# タイトル
+
+記事の内容をここに書きます...
+
+## 見出し2
+
+- リスト項目1
+- リスト項目2
+
+**太字** *斜体* `コード`
+
+```
+コードブロック
+```
+
+[リンク](https://example.com)"
+                height="500px"
+                resize="vertical"
+                fontSize="14px"
+                lineHeight="1.6"
+                fontFamily="'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace"
+                bg={colorMode === 'dark' ? 'gray.800' : 'white'}
+                color={colorMode === 'dark' ? 'white' : 'gray.800'}
+                border="2px solid"
+                borderColor={colorMode === 'dark' ? 'gray.600' : 'gray.200'}
+                borderRadius="md"
+                p={4}
+                _hover={{
+                  borderColor: colorMode === 'dark' ? 'gray.500' : 'gray.300',
+                }}
+                _focus={{
+                  borderColor: 'blue.500',
+                  boxShadow: '0 0 0 1px var(--chakra-colors-blue-500)',
+                  outline: 'none',
+                }}
+              />
+            </Box>
+          </TabPanel>
+          <TabPanel p={0}>
+            <Box
+              height="500px"
+              overflowY="auto"
+              border="2px solid"
+              borderColor={colorMode === 'dark' ? 'gray.600' : 'gray.200'}
+              borderRadius="md"
+              bg={colorMode === 'dark' ? 'gray.800' : 'white'}
+              color={colorMode === 'dark' ? 'white' : 'gray.800'}
+              p={6}
+              sx={{
+                '& h1': {
+                  fontSize: '2xl',
+                  fontWeight: 'bold',
+                  mb: 4,
+                  color: colorMode === 'dark' ? 'blue.300' : 'blue.600',
+                },
+                '& h2': {
+                  fontSize: 'xl',
+                  fontWeight: 'bold',
+                  mb: 3,
+                  mt: 6,
+                  color: colorMode === 'dark' ? 'blue.300' : 'blue.600',
+                },
+                '& h3': {
+                  fontSize: 'lg',
+                  fontWeight: 'bold',
+                  mb: 2,
+                  mt: 4,
+                  color: colorMode === 'dark' ? 'blue.300' : 'blue.600',
+                },
+                '& p': {
+                  mb: 3,
+                  lineHeight: 1.7,
+                },
+                '& ul, & ol': {
+                  mb: 3,
+                  pl: 6,
+                },
+                '& li': {
+                  mb: 1,
+                },
+                '& code': {
+                  bg: colorMode === 'dark' ? 'gray.700' : 'gray.100',
+                  color: colorMode === 'dark' ? 'pink.300' : 'pink.600',
+                  px: 1,
+                  py: 0.5,
+                  borderRadius: 'sm',
+                  fontSize: 'sm',
+                  fontFamily: 'mono',
+                },
+                '& pre': {
+                  bg: colorMode === 'dark' ? 'gray.700' : 'gray.100',
+                  p: 4,
+                  borderRadius: 'md',
+                  overflowX: 'auto',
+                  mb: 3,
+                },
+                '& a': {
+                  color: colorMode === 'dark' ? 'blue.300' : 'blue.600',
+                  textDecoration: 'underline',
+                },
+                '& img': {
+                  maxWidth: '100%',
+                  height: 'auto',
+                  borderRadius: 'md',
+                  mb: 3,
+                },
+              }}
+            >
+              {value ? (
+                <ReactMarkdown>{value}</ReactMarkdown>
+              ) : (
+                <Text color="gray.500" fontStyle="italic">
+                  プレビューするには左側の「編集」タブで記事を書いてください
+                </Text>
+              )}
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </VStack>
+  )
+}
+
+export default PlainTextEditor

--- a/src/components/editor/SimpleMarkdownEditor.tsx
+++ b/src/components/editor/SimpleMarkdownEditor.tsx
@@ -1,0 +1,190 @@
+import React, { useRef, useCallback } from 'react'
+import { 
+  Box, 
+  Textarea, 
+  HStack, 
+  VStack,
+  Button, 
+  useColorMode, 
+  useToast,
+  Text,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel
+} from '@chakra-ui/react'
+import ReactMarkdown from 'react-markdown'
+
+interface SimpleMarkdownEditorProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+const SimpleMarkdownEditor: React.FC<SimpleMarkdownEditorProps> = ({ value, onChange }) => {
+  const { colorMode } = useColorMode()
+  const toast = useToast()
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // 画像をBase64に変換
+  const fileToBase64 = useCallback((file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+  }, [])
+
+  // クリップボードペーストイベント処理
+  const handlePaste = useCallback(async (event: React.ClipboardEvent) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      
+      if (item.type.startsWith('image/')) {
+        event.preventDefault()
+        
+        const file = item.getAsFile()
+        if (!file) continue
+
+        try {
+          const base64 = await fileToBase64(file)
+          const imageMarkdown = `\n![画像](${base64})\n`
+          
+          const textarea = textareaRef.current
+          if (textarea) {
+            const start = textarea.selectionStart
+            const end = textarea.selectionEnd
+            const newValue = value.slice(0, start) + imageMarkdown + value.slice(end)
+            onChange(newValue)
+            
+            setTimeout(() => {
+              textarea.setSelectionRange(start + imageMarkdown.length, start + imageMarkdown.length)
+              textarea.focus()
+            }, 0)
+          } else {
+            onChange(value + imageMarkdown)
+          }
+
+          toast({
+            title: '画像を挿入しました',
+            status: 'success',
+            duration: 2000,
+            isClosable: true,
+          })
+        } catch (error) {
+          console.error('画像の処理中にエラーが発生しました:', error)
+          toast({
+            title: 'エラー',
+            description: '画像の処理に失敗しました',
+            status: 'error',
+            duration: 3000,
+            isClosable: true,
+          })
+        }
+        break
+      }
+    }
+  }, [value, onChange, fileToBase64, toast])
+
+  // Markdownボタン機能
+  const insertMarkdown = useCallback((before: string, after: string = '') => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    const selectedText = value.slice(start, end)
+    
+    const newText = before + selectedText + after
+    const newValue = value.slice(0, start) + newText + value.slice(end)
+    
+    onChange(newValue)
+    
+    setTimeout(() => {
+      textarea.focus()
+      textarea.setSelectionRange(start + before.length, start + before.length + selectedText.length)
+    }, 0)
+  }, [value, onChange])
+
+  return (
+    <VStack spacing={4} align="stretch">
+      {/* ツールバー */}
+      <HStack spacing={2} flexWrap="wrap">
+        <Button size="sm" onClick={() => insertMarkdown('**', '**')}>太字</Button>
+        <Button size="sm" onClick={() => insertMarkdown('*', '*')}>斜体</Button>
+        <Button size="sm" onClick={() => insertMarkdown('# ')}>見出し1</Button>
+        <Button size="sm" onClick={() => insertMarkdown('## ')}>見出し2</Button>
+        <Button size="sm" onClick={() => insertMarkdown('### ')}>見出し3</Button>
+        <Button size="sm" onClick={() => insertMarkdown('- ')}>リスト</Button>
+        <Button size="sm" onClick={() => insertMarkdown('[', '](url)')}>リンク</Button>
+        <Button size="sm" onClick={() => insertMarkdown('`', '`')}>コード</Button>
+        <Button size="sm" onClick={() => insertMarkdown('```\n', '\n```')}>コードブロック</Button>
+      </HStack>
+
+      {/* エディタ */}
+      <Tabs variant="enclosed">
+        <TabList>
+          <Tab>編集</Tab>
+          <Tab>プレビュー</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel p={0}>
+            <Textarea
+              ref={textareaRef}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              onPaste={handlePaste}
+              placeholder="Markdownで記事を書いてください..."
+              height="400px"
+              resize="vertical"
+              fontSize="14px"
+              lineHeight="1.5"
+              fontFamily="Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace"
+              color={colorMode === 'dark' ? 'white' : 'gray.800'}
+              bg={colorMode === 'dark' ? 'gray.700' : 'white'}
+              border="1px solid"
+              borderColor={colorMode === 'dark' ? 'gray.600' : 'gray.200'}
+              _focus={{
+                borderColor: 'blue.500',
+                boxShadow: '0 0 0 1px var(--chakra-colors-blue-500)',
+              }}
+              sx={{
+                '&:focus': {
+                  color: colorMode === 'dark' ? 'white !important' : 'gray.800 !important',
+                },
+                // IME入力時の文字色を強制
+                '&[data-ime-input="true"]': {
+                  color: colorMode === 'dark' ? 'white !important' : 'gray.800 !important',
+                },
+              }}
+            />
+          </TabPanel>
+          <TabPanel p={4}>
+            <Box
+              height="400px"
+              overflowY="auto"
+              border="1px solid"
+              borderColor={colorMode === 'dark' ? 'gray.600' : 'gray.200'}
+              borderRadius="md"
+              bg={colorMode === 'dark' ? 'gray.700' : 'white'}
+              color={colorMode === 'dark' ? 'white' : 'gray.800'}
+              p={4}
+            >
+              {value ? (
+                <ReactMarkdown>{value}</ReactMarkdown>
+              ) : (
+                <Text color="gray.500">プレビューするには左側で記事を書いてください</Text>
+              )}
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </VStack>
+  )
+}
+
+export default SimpleMarkdownEditor

--- a/src/pages/admin/PostEditor.tsx
+++ b/src/pages/admin/PostEditor.tsx
@@ -24,6 +24,8 @@ import {
   clearCurrentPost,
 } from '../../store/slices/postsSlice'
 import MarkdownEditor from '../../components/editor/MarkdownEditor'
+import SimpleMarkdownEditor from '../../components/editor/SimpleMarkdownEditor'
+import PlainTextEditor from '../../components/editor/PlainTextEditor'
 import Loading from '../../components/common/Loading'
 
 const PostEditor: React.FC = () => {
@@ -45,6 +47,8 @@ const PostEditor: React.FC = () => {
     featured_image: '',
     status: 'draft' as 'draft' | 'published',
   })
+
+  const [editorType, setEditorType] = useState<'plain' | 'simple' | 'rich'>('plain') // デフォルトでプレーンエディタを使用
 
   useEffect(() => {
     if (isEdit && id) {
@@ -204,10 +208,48 @@ const PostEditor: React.FC = () => {
 
         <FormControl isRequired>
           <FormLabel>本文</FormLabel>
-          <MarkdownEditor
-            value={formData.content}
-            onChange={(value) => handleChange('content', value)}
-          />
+          <HStack spacing={4} mb={2}>
+            <Button
+              size="sm"
+              variant={editorType === 'plain' ? "solid" : "outline"}
+              colorScheme="blue"
+              onClick={() => setEditorType('plain')}
+            >
+              プレーンエディタ
+            </Button>
+            <Button
+              size="sm"
+              variant={editorType === 'simple' ? "solid" : "outline"}
+              colorScheme="blue"
+              onClick={() => setEditorType('simple')}
+            >
+              シンプルエディタ
+            </Button>
+            <Button
+              size="sm"
+              variant={editorType === 'rich' ? "solid" : "outline"}
+              colorScheme="blue"
+              onClick={() => setEditorType('rich')}
+            >
+              リッチエディタ
+            </Button>
+          </HStack>
+          {editorType === 'plain' ? (
+            <PlainTextEditor
+              value={formData.content}
+              onChange={(value) => handleChange('content', value)}
+            />
+          ) : editorType === 'simple' ? (
+            <SimpleMarkdownEditor
+              value={formData.content}
+              onChange={(value) => handleChange('content', value)}
+            />
+          ) : (
+            <MarkdownEditor
+              value={formData.content}
+              onChange={(value) => handleChange('content', value)}
+            />
+          )}
         </FormControl>
 
         <Divider />


### PR DESCRIPTION
Features:
- Add PlainTextEditor with stylish grouped toolbar (H1/H2/H3, B/I/Code, List/Link, etc.)
- Add SimpleMarkdownEditor with preview tabs
- Enhance MarkdownEditor with better IME support and color fixes
- Add clipboard image paste functionality (Ctrl+V/Cmd+V)
- Implement multiple editor options (Plain/Simple/Rich) in PostEditor
- Fix Japanese text input color issues in all editors
- Add tooltips and visual grouping for better UX

Technical improvements:
- Resolve React Icons TypeScript compatibility issues
- Add dynamic CSS injection for IME text color fixes
- Implement MutationObserver for persistent styling
- Add ReactMarkdown preview with beautiful styling
- Create reusable editor components with consistent interfaces

🤖 Generated with [Claude Code](https://claude.ai/code)